### PR TITLE
Add optional/experimental code to read PMTiles databases using System.FileDescriptor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/sfomuseum/swifter.git", branch:"main"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,5 +28,15 @@ let package = Package(
         .testTarget(
             name: "SwifterProtomapsTests",
             dependencies: ["SwifterProtomaps"]),
+        .executableTarget(
+            name: "swifter-protomaps-server",
+            dependencies: [
+                "SwifterProtomaps",
+                .product(name: "Swifter", package: "swifter"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "Scripts"
+    )
     ]
 )

--- a/Scripts/swifter-protomaps-server/Server.swift
+++ b/Scripts/swifter-protomaps-server/Server.swift
@@ -6,7 +6,7 @@ import Foundation
 
 @available(macOS 14.0, iOS 17.0, tvOS 17.0, *)
 @main
-struct ImageEmbossServer: AsyncParsableCommand {
+struct SwifterProtomapsServer: ParsableCommand {
     
     @Option(help: "The host name to listen for new connections")
     var host: String = "localhost"
@@ -20,7 +20,7 @@ struct ImageEmbossServer: AsyncParsableCommand {
     @Option(help: "Enable verbose logging")
     var verbose: Bool = false
     
-    func run() async throws {
+    func run() throws {
                 
         let log_label = "org.sfomuseum.swift-protomaps"
         let logger = Logger(label: log_label)
@@ -40,8 +40,17 @@ struct ImageEmbossServer: AsyncParsableCommand {
         server["/"] = { request in
             return HttpResponse.ok(.text("Hello world."))
         }
+                
+        let semaphore = DispatchSemaphore(value: 0)
         
-        try server.start(port)
-        
+        do {
+          try server.start(port)
+          logger.info("Server has started on \(port). Try to connect now...")
+          semaphore.wait()
+        } catch {
+            logger.error("Server start error: \(error)")
+          semaphore.signal()
+        }
+
     }
 }

--- a/Scripts/swifter-protomaps-server/Server.swift
+++ b/Scripts/swifter-protomaps-server/Server.swift
@@ -1,0 +1,47 @@
+import ArgumentParser
+import Swifter
+import SwifterProtomaps
+import Logging
+import Foundation
+
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, *)
+@main
+struct ImageEmbossServer: AsyncParsableCommand {
+    
+    @Option(help: "The host name to listen for new connections")
+    var host: String = "localhost"
+    
+    @Option(help: "...")
+    var root: String = ""
+    
+    @Option(help: "The port to listen on for new connections")
+    var port: UInt16 = 8080
+    
+    @Option(help: "Enable verbose logging")
+    var verbose: Bool = false
+    
+    func run() async throws {
+                
+        let log_label = "org.sfomuseum.swift-protomaps"
+        let logger = Logger(label: log_label)
+        
+        let server = HttpServer()
+        let root_url = URL(fileURLWithPath: root)
+        
+        var opts = ServeProtomapsOptions(root: root_url)
+        opts.AllowOrigins = "*"
+        opts.AllowHeaders = "*"
+        opts.Logger = logger
+    
+        opts.StripPrefix = "/pmtiles"
+        
+        server["/pmtiles/:path"] = ServeProtomapsTiles(opts)
+        
+        server["/"] = { request in
+            return HttpResponse.ok(.text("Hello world."))
+        }
+        
+        try server.start(port)
+        
+    }
+}

--- a/Sources/SwifterProtomaps/SwifterProtomaps.swift
+++ b/Sources/SwifterProtomaps/SwifterProtomaps.swift
@@ -136,7 +136,7 @@ public func ServeProtomapsTiles(_ opts: ServeProtomapsOptions) -> ((HttpRequest)
         
         // https://httpwg.org/specs/rfc7233.html#header.accept-ranges
                 
-        var filesize = "*"
+        let filesize = "*"
         
         /*
         do {

--- a/Sources/SwifterProtomaps/SwifterProtomaps.swift
+++ b/Sources/SwifterProtomaps/SwifterProtomaps.swift
@@ -1,6 +1,7 @@
 import Swifter
 import Foundation
 import Logging
+import System
 
 /// ServeProtomapsOptions defines runtime options for serving Protomaps tiles
 public struct ServeProtomapsOptions {
@@ -25,124 +26,165 @@ public struct ServeProtomapsOptions {
 
 /// ServeProtomapsTiles will serve HTTP range requests for zero or more Protomaps tile databases in a directory.
 @available(iOS 13.4, *)
-@available(macOS 10.15.4, *)
+@available(macOS 11.0, *)
 public func ServeProtomapsTiles(_ opts: ServeProtomapsOptions) -> ((HttpRequest) -> HttpResponse) {
+    
+    return { r in
         
-        return { r in
-                   
-            var rsp_headers = [String: String]()
-            
-            guard let req_path = r.params.first else {
-                return .raw(404, "Not found", rsp_headers, {_ in })
-            }
-                            
-            var rel_path = req_path.value
-            
-            if opts.StripPrefix != "" {
-                rel_path = rel_path.replacingOccurrences(of: opts.StripPrefix, with: "")
-            }
-            
-            let uri = opts.Root.appendingPathComponent(rel_path)
-            let path = uri.absoluteString
-            
-            // https://developer.apple.com/documentation/foundation/filehandle
-            
-            var file: FileHandle
-            
-            do {
-                file = try FileHandle(forReadingFrom: uri)
-            } catch {
-                opts.Logger?.error("Failed to open path (\(path)) for reading \(error)")
-                return .raw(404, "Not found", rsp_headers, {_ in })
-            }
-            
-            defer {
-                do {
-                    try file.close()
-                } catch (let error) {
-                    opts.Logger?.warning("Failed to close \(path), \(error)")
-                }
-            }
-            
-            guard var range_h = r.headers["range"] else {
-                rsp_headers["Access-Control-Allow-Origin"] = opts.AllowOrigins
-                rsp_headers["Access-Control-Allow-Headers"] = opts.AllowHeaders
-                return .raw(200, "OK", rsp_headers, {_ in })
-            }
-            
-            let pat = "bytes=(\\d+)-(\\d+)"
-            
-            guard let _ = range_h.range(of: pat, options: .regularExpression) else {
-                rsp_headers["X-Error"] = "Invalid or unsupported range request"
-                return .raw(400, "Bad Request", rsp_headers, {_ in })
-            }
-            
-            range_h = range_h.replacingOccurrences(of: "bytes=", with: "")
-            let positions = range_h.split(separator: "-")
-            
-            if positions.count != 2 {
-                rsp_headers["X-Error"] = "Invalid count for range request"
-                return .raw(400, "Bad Request", rsp_headers, {_ in })
-            }
-            
-            guard let start = UInt64(positions[0]) else {
-                rsp_headers["X-Error"] = "Invalid starting range"
-                return .raw(400, "Bad Request", rsp_headers, {_ in })
-            }
-            
-            guard let stop = Int(positions[1]) else {
-                rsp_headers["X-Error"] = "Invalid stopping range"
-                return .raw(400, "Bad Request", rsp_headers, {_ in })
-            }
-            
-            if start > stop {
-                rsp_headers["X-Error"] = "Invalid range: Start value greater than stop value"
-                return .raw(400, "Bad Request", rsp_headers, {_ in })
-            }
-            
-            let next = stop + 1
-            
-            let body: Data!
+        var rsp_headers = [String: String]()
         
-            file.seek(toFileOffset: start)
-            
+        guard let req_path = r.params.first else {
+            return .raw(404, "Not found", rsp_headers, {_ in })
+        }
+        
+        var rel_path = req_path.value
+        
+        if opts.StripPrefix != "" {
+            rel_path = rel_path.replacingOccurrences(of: opts.StripPrefix, with: "")
+        }
+        
+        let uri = opts.Root.appendingPathComponent(rel_path)
+        let path = uri.absoluteString
+        
+        // https://developer.apple.com/documentation/foundation/filehandle
+        
+        // var file: FileHandle
+        var file: FileDescriptor
+        
+        do {
+            // file = try FileHandle(forReadingFrom: uri)
+            let fp = FilePath(uri.absoluteString)
+            file = try FileDescriptor.open(fp, .readOnly)
+        } catch {
+            opts.Logger?.error("Failed to open path (\(path)) for reading \(error)")
+            return .raw(404, "Not found", rsp_headers, {_ in })
+        }
+        
+        defer {
             do {
-                body = try file.read(upToCount: next)
-            } catch (let error){
-                opts.Logger?.error("Failed to read to \(next) for \(path), \(error)")
-                rsp_headers["X-Error"] = "Failed to read from Protomaps tile"
-                return .raw(500, "Internal Server Error", rsp_headers, {_ in })
+                try file.close()
+            } catch (let error) {
+                opts.Logger?.warning("Failed to close \(path), \(error)")
             }
-
-            // https://httpwg.org/specs/rfc7233.html#header.accept-ranges
-
-            var filesize = "*"
-            
-            do {
-                let size = try file.seekToEnd()
-                filesize = String(size)
-            } catch (let error){
-                opts.Logger?.warning("Failed to determine filesize for \(path), \(error)")
-            }
-            
-            let length = UInt64(next) - start
-            
-            let content_length = String(length)
-            let content_range = "bytes \(start)-\(next)/\(filesize)"
-                        
+        }
+        
+        guard var range_h = r.headers["range"] else {
             rsp_headers["Access-Control-Allow-Origin"] = opts.AllowOrigins
             rsp_headers["Access-Control-Allow-Headers"] = opts.AllowHeaders
-            rsp_headers["Content-Length"] = content_length
-            rsp_headers["Content-Range"] = content_range
-            rsp_headers["Accept-Ranges"] = "bytes"
-                        
-            return .raw(206, "Partial Content", rsp_headers, { writer in
-                
-                do {
-                    try writer.write(body)
-                } catch (let error) {
-                    opts.Logger?.error("Failed to write body, \(error)")
-                }
-            })
+            return .raw(200, "OK", rsp_headers, {_ in })
         }
+        
+        let pat = "bytes=(\\d+)-(\\d+)"
+        
+        guard let _ = range_h.range(of: pat, options: .regularExpression) else {
+            rsp_headers["X-Error"] = "Invalid or unsupported range request"
+            return .raw(400, "Bad Request", rsp_headers, {_ in })
+        }
+        
+        range_h = range_h.replacingOccurrences(of: "bytes=", with: "")
+        let positions = range_h.split(separator: "-")
+        
+        if positions.count != 2 {
+            rsp_headers["X-Error"] = "Invalid count for range request"
+            return .raw(400, "Bad Request", rsp_headers, {_ in })
+        }
+        
+        guard let start = UInt64(positions[0]) else {
+            rsp_headers["X-Error"] = "Invalid starting range"
+            return .raw(400, "Bad Request", rsp_headers, {_ in })
+        }
+        
+        guard let stop = Int(positions[1]) else {
+            rsp_headers["X-Error"] = "Invalid stopping range"
+            return .raw(400, "Bad Request", rsp_headers, {_ in })
+        }
+        
+        if start > stop {
+            rsp_headers["X-Error"] = "Invalid range: Start value greater than stop value"
+            return .raw(400, "Bad Request", rsp_headers, {_ in })
+        }
+        
+        let next = stop + 1
+        
+        // let body: Data!
+        // file.seek(toFileOffset: start)
+        
+        do {
+            try file.seek(offset: Int64(start), from: FileDescriptor.SeekOrigin.start)
+        } catch {
+            opts.Logger?.error("Failed to seek to \(start) for \(path), \(error)")
+            rsp_headers["X-Error"] = "Failed to read from Protomaps tile"
+            return .raw(500, "Internal Server Error", rsp_headers, {_ in })
+        }
+        
+        guard let body = readData(from: file.rawValue, length: next) else {
+            opts.Logger?.error("Failed to read to \(next) for \(path)")
+            rsp_headers["X-Error"] = "Failed to read from Protomaps tile"
+            return .raw(500, "Internal Server Error", rsp_headers, {_ in })
+        }
+            
+        /*
+        do {
+            // body = try file.read(upToCount: next)
+            body = try file.read(upToCount: next)
+        } catch (let error){
+            opts.Logger?.error("Failed to read to \(next) for \(path), \(error)")
+            rsp_headers["X-Error"] = "Failed to read from Protomaps tile"
+            return .raw(500, "Internal Server Error", rsp_headers, {_ in })
+        }
+        */
+        
+        // https://httpwg.org/specs/rfc7233.html#header.accept-ranges
+                
+        var filesize = "*"
+        
+        /*
+        do {
+            let size = try file.seekToEnd()
+            filesize = String(size)
+        } catch (let error){
+            opts.Logger?.warning("Failed to determine filesize for \(path), \(error)")
+        }
+        */
+        
+        let length = UInt64(next) - start
+        
+        let content_length = String(length)
+        let content_range = "bytes \(start)-\(next)/\(filesize)"
+        
+        rsp_headers["Access-Control-Allow-Origin"] = opts.AllowOrigins
+        rsp_headers["Access-Control-Allow-Headers"] = opts.AllowHeaders
+        rsp_headers["Content-Length"] = content_length
+        rsp_headers["Content-Range"] = content_range
+        rsp_headers["Accept-Ranges"] = "bytes"
+        
+        return .raw(206, "Partial Content", rsp_headers, { writer in
+            
+            do {
+                try writer.write(body)
+            } catch (let error) {
+                opts.Logger?.error("Failed to write body, \(error)")
+            }
+        })
     }
+}
+
+internal func readData(from fileDescriptor: Int32, length: Int) -> Data? {
+    // Create a Data buffer of the desired length
+    var data = Data(count: length)
+    
+    // Read the data into the Data buffer
+    let bytesRead = data.withUnsafeMutableBytes { buffer -> Int in
+        guard let baseAddress = buffer.baseAddress else { return -1 }
+        return read(fileDescriptor, baseAddress, length)
+    }
+    
+    // Handle errors or end-of-file
+    guard bytesRead > 0 else {
+        return nil // Return nil if no bytes were read
+    }
+    
+    // Resize the Data object to the actual number of bytes read
+    data.removeSubrange(bytesRead..<data.count)
+    return data
+}


### PR DESCRIPTION
* Add optional/experimental code to read PMTiles databases using `System.FileDescriptor` (rather than `Foundation.FileHandle`)